### PR TITLE
Use existing logging capability

### DIFF
--- a/src/main/java/life/qbic/portal/portlet/OMEROClientPortlet.java
+++ b/src/main/java/life/qbic/portal/portlet/OMEROClientPortlet.java
@@ -172,11 +172,11 @@ public class OMEROClientPortlet extends QBiCPortletUI {
 
             this.omeroSessionKey = ctx.getString("sessionUuid");
 
-            System.out.println(ctx.toString());
+            LOG.info(ctx.toString());
 
         } catch (Exception e) {
-            System.out.println("-->json login fail:");
-            e.printStackTrace();
+            LOG.error("-->json login fail:");
+            LOG.debug(e);
 
         }
 
@@ -233,8 +233,6 @@ public class OMEROClientPortlet extends QBiCPortletUI {
 
 
         oc.connect();
-
-        //System.out.println("+++++++++++++++++++++session id: " + oc.getSessionId());
 
         HashMap<Long, String> projectMap = oc.loadProjects();
         oc.disconnect();
@@ -537,7 +535,7 @@ public class OMEROClientPortlet extends QBiCPortletUI {
 
 
                     } catch (Exception e) {
-                        System.out.println(e);
+                        LOG.error(e);
                     }
 
 


### PR DESCRIPTION
`private static final Logger LOG = LogManager.getLogger(OMEROClientPortlet.class);` was not used.

This PR replaces all `System.out.print()`,  `System.err.print()`, `e.printStackTrace()` calls by calls to the `LOG` object.