### PR TITLE
Bump version to 1.1.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/qbicsoftware/omero-client-portlet.svg?branch=development)](https://travis-ci.com/qbicsoftware/omero-client-portlet)[![Code Coverage]( https://codecov.io/gh/qbicsoftware/omero-client-portlet/branch/development/graph/badge.svg)](https://codecov.io/gh/qbicsoftware/omero-client-portlet)
 
-OMERO Client, version 1.0.0-SNAPSHOT - Java client for the OMERO server
+OMERO Client, version 1.1.0-SNAPSHOT - Java client for the OMERO server
 
 ## Author
 Created by Luis Kuhn Cuellar (luis.kuhn@qbic.uni-tuebingen.de).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>life.qbic</groupId>
 	<artifactId>omero-client-portlet</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<name>OMERO Client</name>
 	<url>http://github.com/qbicsoftware/omero-client-portlet</url>
 	<description>Java client for the OMERO server</description>

--- a/src/test/java/life/qbic/portal/portlet/OMEROClientPortletSpec.groovy
+++ b/src/test/java/life/qbic/portal/portlet/OMEROClientPortletSpec.groovy
@@ -7,7 +7,7 @@ import spock.lang.Specification
  *
  * <detailed description>
  *
- * @since: 1.0.0
+ * @since: 1.1.0
  * @author: Tobias Koch
  */
 class OMEROClientPortletSpec extends Specification {


### PR DESCRIPTION
This commit bumps the version in the `pom.xml` to 1.1.0-SNAPSHOT.
It also corrects the `@since` annotation in classes created after the release of `1.0.1`.