### PR TITLE
Add TLS java VM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ Created by Luis Kuhn Cuellar (luis.kuhn@qbic.uni-tuebingen.de).
 ## Description
 
 ## How to Install
+
+## How to Run
+```bash
+mvn jetty:run -Djava.security.properties="allow_tls.properties"
+```

--- a/allow_tls.properties
+++ b/allow_tls.properties
@@ -1,0 +1,1 @@
+jdk.tls.disabledAlgorithms=SSLv3, DH keySize < 768


### PR DESCRIPTION
Adds information on how to run with `mvn jetty:run`. Also provides `java.security` configuration.

This was necessary due to omero using old TLS algorithms.