### PR TITLE
Fix log4j security issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.3.2 (2021-11-13)
+------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+* org.apache.logging.log4j 2.13.2 -> 2.15.0 (addresses CVE-2021-44228)
+
+**Deprecated**
+
+
 1.3.1 (2021-11-02)
 ------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project
 	xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -12,15 +12,16 @@
 	</parent>
 
 	<artifactId>omero-portlet</artifactId>
-	<version>1.3.1</version> <!-- <<QUBE_FORCE_BUMP>> -->
+	<version>1.3.2</version> <!-- <<QUBE_FORCE_BUMP>> -->
 	<name>omero-portlet</name>
-	<url>http://github.com/qbicsoftware/omero-portlet</url>
+	<url>https://github.com/qbicsoftware/omero-portlet</url>
 	<description>Omero-portlet. An image data visualisation portlet for qPortal.</description>
 	<packaging>war</packaging>
 
 	<properties>
 		<vaadin.version>8.14.0</vaadin.version>
 		<vaadin.plugin.version>8.14.0</vaadin.plugin.version>
+		<log4j.version>2.15.0</log4j.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
1.3.2 (2021-11-13)
------------------

**Added**

**Fixed**

**Dependencies**

* `org.apache.logging.log4j:2.13.2 -> 2.15.0` (addresses CVE-2021-44228)

**Deprecated**
